### PR TITLE
[neophile] Update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
       - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8


### PR DESCRIPTION
- Update pycqa/flake8 pre-commit hook from 3.8.4 to 3.9.0