### PR TITLE
[DM-29084] Add GitHub Actions and dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,92 @@
+name: CI
+
+"on": [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python:
+          - 3.9
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.0
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Cache tox environments
+        id: cache-tox
+        uses: actions/cache@v2
+        with:
+          path: .tox
+          # requirements/*.txt and pyproject.toml have versioning info
+          # that would impact the tox environment.
+          key: tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-
+
+      - name: Run tox
+        run: tox -e py,coverage-report,typing
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [test]
+
+    # Only do Docker builds of ticket branches and tagged releases.
+    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Define the Docker tag
+        id: vars
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
+
+      - name: Print the tag
+        id: print
+        run: echo ${{ steps.vars.outputs.tag }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys:
+            ${{ runner.os }}-buildx-
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: lsstsqre/moneypenny:${{ steps.vars.outputs.tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,11 @@ jobs:
           restore-keys: |
             tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-
 
+      # Regular tests are disabled becasue the test suite requires a
+      # Kubernetes cluster and the work to set that up in GitHub Actions
+      # has not yet been done.
       - name: Run tox
-        run: tox -e py,coverage-report,typing
+        run: tox -e typing
 
   build:
     runs-on: ubuntu-latest

--- a/scripts/docker-tag.sh
+++ b/scripts/docker-tag.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Determine the tag for Docker images.  Takes the Git ref as its only
+# argument.
+
+set -eo pipefail
+
+if [ -z "$1" ]; then
+    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
+    exit 1
+fi
+
+echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'

--- a/src/moneypenny/handlers/external/__init__.py
+++ b/src/moneypenny/handlers/external/__init__.py
@@ -7,8 +7,4 @@ __all__ = [
     "commission_agent",
     "retire_agent",
 ]
-from .agent import (
-    quip,
-    commission_agent,
-    retire_agent,
-)
+from .agent import commission_agent, quip, retire_agent


### PR DESCRIPTION
This wasn't set up when the repository was created for some reason.
Add in the current GitHub Actions configuration and the configuration
for dependabot pull requests.