### PR TITLE
[DM-32811] Fix race condition on commission/retire

### DIFF
--- a/src/moneypenny/config.py
+++ b/src/moneypenny/config.py
@@ -66,6 +66,9 @@ class Configuration:
     """Path to Moneypenny's quip file.  Leave at default in normal operation.
     """
 
+    podinfo_dir: str = os.getenv("MONEYPENNY_PODINFO_DIR", "/etc/podinfo")
+    """Path at which Kubernetes has mounted the pod metadata files."""
+
     moneypenny_timeout: int = int(os.getenv("MONEYPENNY_TIMEOUT") or "300")
     """Timeout (in seconds) to wait for all containers in the action pod to
     complete.  Defaults to 300.

--- a/src/moneypenny/kubernetes.py
+++ b/src/moneypenny/kubernetes.py
@@ -303,7 +303,18 @@ class KubernetesClient:
         djson = json.dumps(dossier.dict(), sort_keys=True, indent=4)
         data = {"dossier.json": djson}
         cm = V1ConfigMap(
-            metadata=V1ObjectMeta(name=cmname, namespace=self.namespace),
+            metadata=V1ObjectMeta(
+                name=cmname,
+                namespace=self.namespace,
+                owner_references=[
+                    V1OwnerReference(
+                        api_version="v1",
+                        kind="Pod",
+                        name=_read_pod_info("name"),
+                        uid=_read_pod_info("uid"),
+                    )
+                ],
+            ),
             data=data,
         )
         return cm

--- a/src/moneypenny/main.py
+++ b/src/moneypenny/main.py
@@ -25,6 +25,7 @@ configure_logging(
     profile=config.profile,
     log_level=config.log_level,
     name=config.logger_name,
+    add_timestamp=True,
 )
 
 app = FastAPI()

--- a/src/moneypenny/moneypenny.py
+++ b/src/moneypenny/moneypenny.py
@@ -85,19 +85,9 @@ class Moneypenny:
         return vols
 
     async def dispatch_order(self, action: str, dossier: Dossier) -> None:
-        """Start a background task to carry out an order.
+        """Start processing an order.
 
-        This is done instead of using FastAPI's ``BackgroundTasks`` directly
-        because httpx's ``AsyncClient`` blocks return from a call to a test
-        app until all background tasks have completed, which isn't the
-        behavior we want to test.  This technique was taken from
-        https://stackoverflow.com/questions/68542054/
-        """
-        loop = asyncio.get_event_loop()
-        loop.create_task(self.execute_order(action, dossier))
-
-    async def execute_order(self, action: str, dossier: Dossier) -> None:
-        """Carry out an order based on standing orders and the dossier
+        Carry out an order based on standing orders and the dossier
         supplied.  This amounts to asking our Kubernetes client to create
         a ConfigMap from the dossier, and then creating a pod with
         containers from the list of containers specified in the standing
@@ -109,9 +99,10 @@ class Moneypenny:
 
         Parameters
         ----------
-        action: The action to execute.
-        dossier: Dossier associated with the order for the user.
-
+        action : `str`
+            The action to execute.
+        dossier : `moneypenny.models.Dossier`
+            Dossier associated with the order for the user.
         """
         username = dossier.username
         logger.info(f"Submitting order '{action}' for {username}")
@@ -120,18 +111,44 @@ class Moneypenny:
         if not containers:
             logger.warning("Empty order for {action}")
             return
-        pull_secret_name = config.docker_secret_name
         await self.k8s_client.make_objects(
             username=username,
             containers=containers,
             volumes=volumes,
             dossier=dossier,
-            pull_secret_name=pull_secret_name,
+            pull_secret_name=config.docker_secret_name,
         )
+
+    async def wait_for_order(self, action: str, username: str) -> None:
+        """Start a background task to wait for order completion.
+
+        This is done instead of using FastAPI's ``BackgroundTasks`` directly
+        because httpx's ``AsyncClient`` blocks return from a call to a test
+        app until all background tasks have completed, which isn't the
+        behavior we want to test.  This technique was taken from
+        https://stackoverflow.com/questions/68542054/
+        """
+        loop = asyncio.get_event_loop()
+        loop.create_task(self._wait_for_order(action, username))
+
+    async def _wait_for_order(self, action: str, username: str) -> None:
+        """Wait for an order to complete.
+
+        This is the internal implementation of `wait_for_order`.  Wait for a
+        running pod for a given user to complete and then clean up the
+        resources.
+
+        Parameters
+        ----------
+        action : `str`
+            The action in progress, for logging.
+        username : `str`
+            The username whose pod we're waiting for.
+        """
         tmout = config.moneypenny_timeout
         expiry = datetime.datetime.now() + datetime.timedelta(seconds=tmout)
-        # Wait for order to complete
         logger.info(f"Awaiting completion for '{action}': {username}")
+
         count = 0
         while datetime.datetime.now() < expiry:
             count += 1
@@ -145,24 +162,26 @@ class Moneypenny:
                 finito = True
             if finito:
                 logger.info(
-                    f"Order '{action}' {completed_str} for {username}: "
-                    + "tidying up."
+                    f"Order '{action}' {completed_str} for {username}:"
+                    " tidying up"
                 )
                 await self.k8s_client.delete_objects(username)
                 logger.info(
                     f"Tidied up after '{action}' for {username};"
-                    + " awaiting further instructions."
+                    " awaiting further instructions"
                 )
                 return
+
             # logarithmic backoff on wait
             assert count < 10
             await asyncio.sleep(int(log(count)))
+
         # Timed out
-        estr = f"Pod '{action}' for {username} did not complete in {tmout}s"
-        logger.exception(estr)
-        logger.info(f"Attempting tidy-up for {username}.")
+        msg = f"Pod '{action}' for {username} did not complete in {tmout}s"
+        logger.error(msg)
+        logger.info(f"Attempting tidy-up for {username}")
         await self.k8s_client.delete_objects(username)
-        raise NoMrBondIExpectYouToDie(estr)
+        raise NoMrBondIExpectYouToDie(msg)
 
     async def check_completed(self, username: str) -> bool:
         """Check on the completion status of an order's execution.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ import moneypenny.kubernetes
 from moneypenny import main
 from moneypenny.config import config
 from moneypenny.models import Dossier, Group
+from tests.support.constants import TEST_HOSTNAME
 from tests.support.kubernetes import MockKubernetesApi
 
 if TYPE_CHECKING:
@@ -42,7 +43,8 @@ async def app(mock_kubernetes: MockKubernetesApi) -> AsyncIterator[FastAPI]:
 @pytest.fixture
 async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
-    async with AsyncClient(app=app, base_url="https://example.com/") as client:
+    base_url = f"https://{TEST_HOSTNAME}/"
+    async with AsyncClient(app=app, base_url=base_url) as client:
         yield client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,9 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-async def app(mock_kubernetes: MockKubernetesApi) -> AsyncIterator[FastAPI]:
+async def app(
+    mock_kubernetes: MockKubernetesApi, podinfo: Path
+) -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -55,6 +57,19 @@ def dossier() -> Dossier:
         uid=1007,
         groups=[Group(name="doubleos", id=500), Group(name="staff", id=200)],
     )
+
+
+@pytest.fixture
+def podinfo(tmp_path: Path) -> Iterator[Path]:
+    """Store some mock Kubernetes pod information and override config."""
+    orig_podinfo_dir = config.podinfo_dir
+    podinfo_dir = tmp_path / "podinfo"
+    podinfo_dir.mkdir()
+    (podinfo_dir / "name").write_text("moneypenny-78547dcf97-9xqq8")
+    (podinfo_dir / "uid").write_text("00386592-214f-40c5-88e1-b9657d53a7c6")
+    config.podinfo_dir = str(podinfo_dir)
+    yield podinfo_dir
+    config.podinfo_dir = orig_podinfo_dir
 
 
 @pytest.fixture

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -12,6 +12,7 @@ from kubernetes_asyncio.client import (
     V1ConfigMap,
     V1ConfigMapVolumeSource,
     V1ObjectMeta,
+    V1OwnerReference,
     V1Pod,
     V1PodSecurityContext,
     V1PodSpec,
@@ -79,6 +80,14 @@ async def test_route_commission(
                 metadata=V1ObjectMeta(
                     name=f"{dossier.username}-pod",
                     namespace="default",
+                    owner_references=[
+                        V1OwnerReference(
+                            api_version="v1",
+                            kind="Pod",
+                            name="moneypenny-78547dcf97-9xqq8",
+                            uid="00386592-214f-40c5-88e1-b9657d53a7c6",
+                        )
+                    ],
                 ),
                 spec=V1PodSpec(
                     automount_service_account_token=False,
@@ -177,6 +186,14 @@ async def test_route_retire(
                 metadata=V1ObjectMeta(
                     name=f"{dossier.username}-pod",
                     namespace="default",
+                    owner_references=[
+                        V1OwnerReference(
+                            api_version="v1",
+                            kind="Pod",
+                            name="moneypenny-78547dcf97-9xqq8",
+                            uid="00386592-214f-40c5-88e1-b9657d53a7c6",
+                        )
+                    ],
                 ),
                 spec=V1PodSpec(
                     automount_service_account_token=False,

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -62,7 +62,16 @@ async def test_route_commission(
         [
             V1ConfigMap(
                 metadata=V1ObjectMeta(
-                    name=f"{dossier.username}-cm", namespace="default"
+                    name=f"{dossier.username}-cm",
+                    namespace="default",
+                    owner_references=[
+                        V1OwnerReference(
+                            api_version="v1",
+                            kind="Pod",
+                            name="moneypenny-78547dcf97-9xqq8",
+                            uid="00386592-214f-40c5-88e1-b9657d53a7c6",
+                        )
+                    ],
                 ),
                 data={
                     "dossier.json": json.dumps(
@@ -168,7 +177,16 @@ async def test_route_retire(
         [
             V1ConfigMap(
                 metadata=V1ObjectMeta(
-                    name=f"{dossier.username}-cm", namespace="default"
+                    name=f"{dossier.username}-cm",
+                    namespace="default",
+                    owner_references=[
+                        V1OwnerReference(
+                            api_version="v1",
+                            kind="Pod",
+                            name="moneypenny-78547dcf97-9xqq8",
+                            uid="00386592-214f-40c5-88e1-b9657d53a7c6",
+                        )
+                    ],
                 ),
                 data={
                     "dossier.json": json.dumps(

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import yaml
+from kubernetes_asyncio.client import V1OwnerReference
 
 from moneypenny.config import config
 from moneypenny.kubernetes import KubernetesClient
@@ -64,7 +65,17 @@ def test_make_pod(app: FastAPI, dossier: Dossier) -> None:
         containers=containers,
         dossier=dossier,
     )
+
+    # Check the metadata.
     assert pod.metadata.name == f"{dossier.username}-pod"
+    assert pod.metadata.owner_references == [
+        V1OwnerReference(
+            api_version="v1",
+            kind="Pod",
+            name="moneypenny-78547dcf97-9xqq8",
+            uid="00386592-214f-40c5-88e1-b9657d53a7c6",
+        )
+    ]
 
 
 def test_make_configmap(app: FastAPI, dossier: Dossier) -> None:

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -85,3 +85,11 @@ def test_make_configmap(app: FastAPI, dossier: Dossier) -> None:
     cmap = client._create_dossier_configmap(dossier=dossier)
     assert cmap.data["dossier.json"] == djson
     assert cmap.metadata.name == f"{dossier.username}-cm"
+    assert cmap.metadata.owner_references == [
+        V1OwnerReference(
+            api_version="v1",
+            kind="Pod",
+            name="moneypenny-78547dcf97-9xqq8",
+            uid="00386592-214f-40c5-88e1-b9657d53a7c6",
+        )
+    ]

--- a/tests/moneypenny_test.py
+++ b/tests/moneypenny_test.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import structlog
+
 from moneypenny.moneypenny import Moneypenny
 
 if TYPE_CHECKING:
@@ -16,27 +18,27 @@ if TYPE_CHECKING:
 
 def test_read_quips(app: FastAPI) -> None:
     """Load quips, make sure we got a single item."""
-    moneypenny = Moneypenny(MagicMock())
+    moneypenny = Moneypenny(MagicMock(), structlog.get_logger(__name__))
     quips = moneypenny._read_quips()
     assert len(quips) == 1
 
 
 def test_quip(app: FastAPI) -> None:
     """The asset only has a single quip.  Make sure we got it."""
-    moneypenny = Moneypenny(MagicMock())
+    moneypenny = Moneypenny(MagicMock(), structlog.get_logger(__name__))
     quip = moneypenny.quip().strip()
     assert quip == "Flattery will get you nowhere... but don't stop trying."
 
 
 def test_read_orders(app: FastAPI) -> None:
     """Ensure we read the order file correctly."""
-    moneypenny = Moneypenny(MagicMock())
+    moneypenny = Moneypenny(MagicMock(), structlog.get_logger(__name__))
     containers = moneypenny._read_order("commission")
     assert containers[0]["name"] == "farthing"
 
 
 def test_read_volumes(app: FastAPI) -> None:
     """Ensure we read the (empty) volume list from the order file."""
-    moneypenny = Moneypenny(MagicMock())
+    moneypenny = Moneypenny(MagicMock(), structlog.get_logger(__name__))
     volumes = moneypenny._read_volumes()
     assert not volumes and volumes is not None

--- a/tests/support/constants.py
+++ b/tests/support/constants.py
@@ -1,0 +1,4 @@
+"""Constants used in test fixtures and setup."""
+
+TEST_HOSTNAME = "example.com"
+"""The hostname used in ASGI requests to the application."""


### PR DESCRIPTION
The previous implementation was returning success and then creating
the pod as a background task.  Unfortunately, this meant we raced
with the client polling status, and might return 404 because the
pods hadn't been created yet now that the Kubernetes code is also
async.

Fix this by changing the API to start the pod before returning a
response and returning a redirect to the status endpoint instead of
a 202 response.  Only background the code that waits for the pod to
complete and then cleans up.

Also use the Safir logger dependency with timestamps, and set owners
on created resources so that they will appear in Argo CD.